### PR TITLE
Switch to libtrails.app domain

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -5,13 +5,11 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@astrojs/react';
 import node from '@astrojs/node';
 
-const isProduction = process.env.NODE_ENV === 'production';
-
 // https://astro.build/config
 export default defineConfig({
   output: 'server',
   adapter: node({ mode: 'standalone' }),
-  base: isProduction ? '/libtrails' : '/',
+  base: '/',
   vite: {
     plugins: [tailwindcss()],
     server: {


### PR DESCRIPTION
## Summary
- Remove `/libtrails` base path prefix — site now served at root `/` on dedicated domain
- Caddy config updated on server to serve `libtrails.app`, redirect `libtrails.com` → `libtrails.app`, and redirect `sbergman.net/libtrails` → `libtrails.app`

## Test plan
- [ ] `libtrails.app` loads the site at root
- [ ] `libtrails.com` redirects to `libtrails.app`
- [ ] `sbergman.net/libtrails` redirects to `libtrails.app`
- [ ] API calls work at `/api/v1/*`
- [ ] Book covers, links, and navigation all use correct paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized application base path configuration to ensure consistent behavior across all deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->