### PR TITLE
feat: mobile responsiveness improvements (#33)

### DIFF
--- a/web/src/components/GalaxyView.tsx
+++ b/web/src/components/GalaxyView.tsx
@@ -18,6 +18,21 @@ const SIDEBAR_WIDTH = 340;
 const SCENE_BG_DARK = "#0f0f1a";
 const SCENE_BG_LIGHT = "#e8e8f0";
 
+function useIsMobile(breakpoint = 767) {
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.innerWidth <= breakpoint;
+  });
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${breakpoint}px)`);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    setIsMobile(mql.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [breakpoint]);
+  return isMobile;
+}
+
 function useThemeMode() {
   const [theme, setTheme] = useState<"dark" | "light">(() => {
     if (typeof document === "undefined") return "dark";
@@ -282,6 +297,7 @@ interface SidebarProps {
   onSelectCluster: (cluster: UniverseCluster) => void;
   onClose: () => void;
   colors: SidebarColors;
+  isMobile: boolean;
 }
 
 function Sidebar({
@@ -295,6 +311,7 @@ function Sidebar({
   onSelectCluster,
   onClose,
   colors,
+  isMobile,
 }: SidebarProps) {
   const basePath = (import.meta.env.BASE_URL || "/").replace(/\/$/, "");
 
@@ -304,9 +321,28 @@ function Sidebar({
     return m;
   }, [domains]);
 
-  return (
-    <div
-      style={{
+  const containerStyle: React.CSSProperties = isMobile
+    ? {
+        position: "absolute",
+        bottom: 0,
+        left: 0,
+        right: 0,
+        height: "60vh",
+        background: colors.bg,
+        borderTop: `1px solid ${colors.border}`,
+        backdropFilter: "blur(12px)",
+        zIndex: 45,
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: "Inter, sans-serif",
+        color: colors.text,
+        overflowY: "auto",
+        overflowX: "hidden",
+        paddingTop: 0,
+        borderRadius: "16px 16px 0 0",
+        transition: "transform 0.2s ease, background 0.15s ease",
+      }
+    : {
         position: "absolute",
         top: 0,
         right: 0,
@@ -324,8 +360,30 @@ function Sidebar({
         overflowX: "hidden",
         paddingTop: 52,
         transition: "transform 0.2s ease, background 0.15s ease",
-      }}
-    >
+      };
+
+  return (
+    <div style={containerStyle}>
+      {/* Drag handle for mobile */}
+      {isMobile && (
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            padding: "10px 0 4px",
+            flexShrink: 0,
+          }}
+        >
+          <div
+            style={{
+              width: 36,
+              height: 4,
+              borderRadius: 2,
+              background: colors.textFaint,
+            }}
+          />
+        </div>
+      )}
       {selectedClusters.length === 1 ? (
         <ClusterPanel
           cluster={selectedClusters[0]}
@@ -352,6 +410,7 @@ function Sidebar({
           onToggle={onToggleDomain}
           onClear={onClearDomainFilter}
           colors={colors}
+          isMobile={isMobile}
         />
       )}
     </div>
@@ -1043,13 +1102,20 @@ function DomainLegend({
   onToggle,
   onClear,
   colors,
+  isMobile,
 }: {
   domains: UniverseDomain[];
   activeDomains: Set<number> | null;
   onToggle: (id: number) => void;
   onClear: () => void;
   colors: SidebarColors;
+  isMobile: boolean;
 }) {
+  const [expanded, setExpanded] = useState(!isMobile);
+  const MOBILE_LIMIT = 10;
+  const visibleDomains = expanded ? domains : domains.slice(0, MOBILE_LIMIT);
+  const hiddenCount = domains.length - MOBILE_LIMIT;
+
   return (
     <div style={{ padding: "16px" }}>
       <div
@@ -1081,7 +1147,7 @@ function DomainLegend({
           </button>
         )}
       </div>
-      {domains.map((d) => (
+      {visibleDomains.map((d) => (
         <div
           key={d.domain_id}
           onClick={() => onToggle(d.domain_id)}
@@ -1119,6 +1185,37 @@ function DomainLegend({
         </div>
       ))}
 
+      {isMobile && !expanded && hiddenCount > 0 && (
+        <button
+          onClick={() => setExpanded(true)}
+          style={{
+            background: "none",
+            border: "none",
+            color: colors.accent,
+            cursor: "pointer",
+            fontSize: "0.72rem",
+            padding: "6px 0",
+          }}
+        >
+          +{hiddenCount} more domains
+        </button>
+      )}
+      {isMobile && expanded && hiddenCount > 0 && (
+        <button
+          onClick={() => setExpanded(false)}
+          style={{
+            background: "none",
+            border: "none",
+            color: colors.accent,
+            cursor: "pointer",
+            fontSize: "0.72rem",
+            padding: "6px 0",
+          }}
+        >
+          Show less
+        </button>
+      )}
+
       <div
         style={{
           marginTop: 20,
@@ -1129,11 +1226,21 @@ function DomainLegend({
           lineHeight: 1.5,
         }}
       >
-        Click a sphere to explore
-        <br />
-        Shift+drag to select multiple
-        <br />
-        Drag to rotate · Scroll to zoom
+        {isMobile ? (
+          <>
+            Tap a sphere to explore
+            <br />
+            Pinch to zoom · Drag to rotate
+          </>
+        ) : (
+          <>
+            Click a sphere to explore
+            <br />
+            Shift+drag to select multiple
+            <br />
+            Drag to rotate · Scroll to zoom
+          </>
+        )}
       </div>
     </div>
   );
@@ -1164,6 +1271,7 @@ const EMPTY_SET = new Set<number>();
 
 export default function GalaxyView() {
   const themeMode = useThemeMode();
+  const isMobile = useIsMobile();
   const [data, setData] = useState<UniverseData | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [activeDomains, setActiveDomains] = useState<Set<number> | null>(null);
@@ -1464,6 +1572,7 @@ export default function GalaxyView() {
         onSelectCluster={handleSelectSingleFromMulti}
         onClose={handleClickEmpty}
         colors={sidebarColors}
+        isMobile={isMobile}
       />
     </div>
   );

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -44,7 +44,8 @@ const isActive = (path: string) => {
           <img src="/libtrails_transparent_128.png" alt="" width="44" height="44" style="border-radius:9px;" />
           LibTrails
         </a>
-        <div class="flex items-center gap-6">
+        <!-- Desktop nav links -->
+        <div class="hidden md:flex items-center gap-6">
           <a href={url("/")} class:list={["text-sm transition-colors", isActive("/") ? "text-[var(--color-accent)]" : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"]}>
             Universe
           </a>
@@ -77,8 +78,59 @@ const isActive = (path: string) => {
             </svg>
           </button>
         </div>
+
+        <!-- Mobile hamburger button -->
+        <button id="mobile-menu-btn" aria-label="Open menu" class="md:hidden text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors cursor-pointer" style="background:none;border:none;padding:0.25rem;">
+          <svg id="hamburger-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="3" y1="6" x2="21" y2="6"></line>
+            <line x1="3" y1="12" x2="21" y2="12"></line>
+            <line x1="3" y1="18" x2="21" y2="18"></line>
+          </svg>
+          <svg id="close-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none;">
+            <line x1="18" y1="6" x2="6" y2="18"></line>
+            <line x1="6" y1="6" x2="18" y2="18"></line>
+          </svg>
+        </button>
       </div>
     </nav>
+
+    <!-- Mobile menu dropdown -->
+    <div id="mobile-menu" class="md:hidden hidden fixed top-[53px] left-0 right-0 z-40 bg-[var(--color-surface)] border-b border-[var(--color-border)]">
+      <div class="flex flex-col px-6 py-3 gap-1">
+        <a href={url("/")} class:list={["block py-2 text-sm transition-colors", isActive("/") ? "text-[var(--color-accent)]" : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"]}>
+          Universe
+        </a>
+        <a href={url("/themes")} class:list={["block py-2 text-sm transition-colors", isActive("/themes") ? "text-[var(--color-accent)]" : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"]}>
+          Themes
+        </a>
+        <a href={url("/clusters")} class:list={["block py-2 text-sm transition-colors", isActive("/clusters") ? "text-[var(--color-accent)]" : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"]}>
+          Clusters
+        </a>
+        <a href={url("/books")} class:list={["block py-2 text-sm transition-colors", isActive("/books") ? "text-[var(--color-accent)]" : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"]}>
+          Books
+        </a>
+        <a href={url("/about")} class:list={["block py-2 text-sm transition-colors", isActive("/about") ? "text-[var(--color-accent)]" : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"]}>
+          About
+        </a>
+        <button id="mobile-theme-toggle" aria-label="Toggle theme" class="flex items-center gap-2 py-2 text-sm text-[var(--color-text-muted)] hover:text-[var(--color-accent)] transition-colors cursor-pointer" style="background:none;border:none;padding:0.5rem 0;text-align:left;">
+          <svg class="theme-icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="5"></circle>
+            <line x1="12" y1="1" x2="12" y2="3"></line>
+            <line x1="12" y1="21" x2="12" y2="23"></line>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+            <line x1="1" y1="12" x2="3" y2="12"></line>
+            <line x1="21" y1="12" x2="23" y2="12"></line>
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+          </svg>
+          <svg class="theme-icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+          </svg>
+          <span>Toggle theme</span>
+        </button>
+      </div>
+    </div>
 
     <!-- Main content -->
     <main class="max-w-6xl mx-auto px-6 py-8">
@@ -101,19 +153,38 @@ const isActive = (path: string) => {
 
     <script is:inline>
       (function() {
-        const btn = document.getElementById('theme-toggle');
-        if (!btn) return;
-        btn.addEventListener('click', function() {
-          const html = document.documentElement;
-          const current = html.getAttribute('data-theme');
-          const next = current === 'light' ? 'dark' : 'light';
+        // Theme toggle (desktop)
+        var btn = document.getElementById('theme-toggle');
+        function toggleTheme() {
+          var html = document.documentElement;
+          var current = html.getAttribute('data-theme');
+          var next = current === 'light' ? 'dark' : 'light';
           if (next === 'dark') {
             html.removeAttribute('data-theme');
           } else {
             html.setAttribute('data-theme', next);
           }
           localStorage.setItem('libtrails-theme', next);
-        });
+        }
+        if (btn) btn.addEventListener('click', toggleTheme);
+
+        // Theme toggle (mobile)
+        var mobileThemeBtn = document.getElementById('mobile-theme-toggle');
+        if (mobileThemeBtn) mobileThemeBtn.addEventListener('click', toggleTheme);
+
+        // Hamburger menu toggle
+        var menuBtn = document.getElementById('mobile-menu-btn');
+        var mobileMenu = document.getElementById('mobile-menu');
+        var hamburgerIcon = document.getElementById('hamburger-icon');
+        var closeIcon = document.getElementById('close-icon');
+        if (menuBtn && mobileMenu) {
+          menuBtn.addEventListener('click', function() {
+            var isOpen = !mobileMenu.classList.contains('hidden');
+            mobileMenu.classList.toggle('hidden');
+            if (hamburgerIcon) hamburgerIcon.style.display = isOpen ? '' : 'none';
+            if (closeIcon) closeIcon.style.display = isOpen ? 'none' : '';
+          });
+        }
       })();
     </script>
   </body>

--- a/web/src/layouts/GalaxyLayout.astro
+++ b/web/src/layouts/GalaxyLayout.astro
@@ -103,6 +103,60 @@ const isActive = (path: string) => {
       .galaxy-nav .theme-toggle:hover {
         color: var(--color-accent);
       }
+      /* Mobile hamburger */
+      .galaxy-nav .hamburger-btn {
+        display: none;
+        background: none;
+        border: none;
+        padding: 0.25rem;
+        color: var(--color-text-muted);
+        cursor: pointer;
+        transition: color 0.15s ease;
+      }
+      .galaxy-nav .hamburger-btn:hover {
+        color: var(--color-accent);
+      }
+      .galaxy-mobile-menu {
+        display: none;
+        position: fixed;
+        top: 53px;
+        left: 0;
+        right: 0;
+        z-index: 49;
+        background: color-mix(in srgb, var(--color-surface) 95%, transparent);
+        backdrop-filter: blur(12px);
+        border-bottom: 1px solid var(--color-border);
+        flex-direction: column;
+        padding: 0.75rem 1.5rem;
+        gap: 0.25rem;
+      }
+      .galaxy-mobile-menu.open {
+        display: flex;
+      }
+      .galaxy-mobile-menu a,
+      .galaxy-mobile-menu button {
+        display: block;
+        padding: 0.5rem 0;
+        font-size: 0.875rem;
+        color: var(--color-text-muted);
+        text-decoration: none;
+        transition: color 0.15s ease;
+        background: none;
+        border: none;
+        cursor: pointer;
+        text-align: left;
+      }
+      .galaxy-mobile-menu a:hover,
+      .galaxy-mobile-menu button:hover {
+        color: var(--color-text);
+      }
+      .galaxy-mobile-menu a.active {
+        color: var(--color-accent);
+      }
+      @media (max-width: 767px) {
+        .galaxy-nav .links { display: none; }
+        .galaxy-nav .hamburger-btn { display: block; }
+      }
       /* Show/hide sun/moon icons based on theme */
       .theme-icon-moon { display: none; }
       [data-theme="light"] .theme-icon-sun { display: none; }
@@ -146,7 +200,46 @@ const isActive = (path: string) => {
           </svg>
         </button>
       </div>
+
+      <!-- Mobile hamburger button -->
+      <button class="hamburger-btn" id="galaxy-menu-btn" aria-label="Open menu">
+        <svg id="galaxy-hamburger-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+        <svg id="galaxy-close-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none;">
+          <line x1="18" y1="6" x2="6" y2="18"></line>
+          <line x1="6" y1="6" x2="18" y2="18"></line>
+        </svg>
+      </button>
     </nav>
+
+    <!-- Mobile dropdown menu -->
+    <div class="galaxy-mobile-menu" id="galaxy-mobile-menu">
+      <a href={url("/")} class:list={[isActive("/") && "active"]}>Universe</a>
+      <a href={url("/themes")} class:list={[isActive("/themes") && "active"]}>Themes</a>
+      <a href={url("/clusters")} class:list={[isActive("/clusters") && "active"]}>Clusters</a>
+      <a href={url("/books")} class:list={[isActive("/books") && "active"]}>Books</a>
+      <a href={url("/about")} class:list={[isActive("/about") && "active"]}>About</a>
+      <button id="galaxy-mobile-theme-toggle" style="display:flex;align-items:center;gap:0.5rem;">
+        <svg class="theme-icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="5"></circle>
+          <line x1="12" y1="1" x2="12" y2="3"></line>
+          <line x1="12" y1="21" x2="12" y2="23"></line>
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+          <line x1="1" y1="12" x2="3" y2="12"></line>
+          <line x1="21" y1="12" x2="23" y2="12"></line>
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+        </svg>
+        <svg class="theme-icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+        </svg>
+        <span>Toggle theme</span>
+      </button>
+    </div>
 
     <div class="galaxy-content">
       <slot />
@@ -154,19 +247,36 @@ const isActive = (path: string) => {
 
     <script is:inline>
       (function() {
-        const btn = document.getElementById('theme-toggle');
-        if (!btn) return;
-        btn.addEventListener('click', function() {
-          const html = document.documentElement;
-          const current = html.getAttribute('data-theme');
-          const next = current === 'light' ? 'dark' : 'light';
+        // Theme toggle
+        function toggleTheme() {
+          var html = document.documentElement;
+          var current = html.getAttribute('data-theme');
+          var next = current === 'light' ? 'dark' : 'light';
           if (next === 'dark') {
             html.removeAttribute('data-theme');
           } else {
             html.setAttribute('data-theme', next);
           }
           localStorage.setItem('libtrails-theme', next);
-        });
+        }
+        var btn = document.getElementById('theme-toggle');
+        if (btn) btn.addEventListener('click', toggleTheme);
+        var mobileThemeBtn = document.getElementById('galaxy-mobile-theme-toggle');
+        if (mobileThemeBtn) mobileThemeBtn.addEventListener('click', toggleTheme);
+
+        // Hamburger menu toggle
+        var menuBtn = document.getElementById('galaxy-menu-btn');
+        var mobileMenu = document.getElementById('galaxy-mobile-menu');
+        var hamburgerIcon = document.getElementById('galaxy-hamburger-icon');
+        var closeIcon = document.getElementById('galaxy-close-icon');
+        if (menuBtn && mobileMenu) {
+          menuBtn.addEventListener('click', function() {
+            var isOpen = mobileMenu.classList.contains('open');
+            mobileMenu.classList.toggle('open');
+            if (hamburgerIcon) hamburgerIcon.style.display = isOpen ? '' : 'none';
+            if (closeIcon) closeIcon.style.display = isOpen ? 'none' : '';
+          });
+        }
       })();
     </script>
   </body>

--- a/web/src/pages/themes/index.astro
+++ b/web/src/pages/themes/index.astro
@@ -16,10 +16,34 @@ const domains = await getDomains();
     </p>
   </header>
 
-  <div class="flex gap-6" id="domain-browser">
-    <!-- Left panel: Domain list -->
-    <div class="w-64 flex-shrink-0">
-      <div class="sticky top-24 space-y-1">
+  <div class="flex flex-col md:flex-row gap-6" id="domain-browser">
+    <!-- Domain selector: horizontal scroll on mobile, vertical list on desktop -->
+    <div class="w-full md:w-64 md:flex-shrink-0">
+      <!-- Mobile: wrapping chip layout with show more -->
+      <div class="flex md:hidden flex-wrap gap-1.5 pb-3" id="mobile-chips">
+        {domains.map((domain, index) => (
+          <button
+            class:list={[
+              "domain-item px-2.5 py-1 rounded-full text-xs font-medium transition-all duration-200 border whitespace-nowrap data-[selected]:bg-[var(--color-accent)] data-[selected]:text-white data-[selected]:border-[var(--color-accent)] bg-[var(--color-surface)] text-[var(--color-text)] border-[var(--color-border)]",
+              index >= 8 && "mobile-chip-overflow hidden"
+            ]}
+            data-domain-id={domain.domain_id}
+            data-selected={index === 0 ? "true" : undefined}
+          >
+            {domain.label}
+          </button>
+        ))}
+        {domains.length > 8 && (
+          <button
+            id="mobile-chips-toggle"
+            class="px-2.5 py-1 rounded-full text-xs font-medium border border-[var(--color-border)] text-[var(--color-accent)] bg-transparent transition-colors hover:bg-[var(--color-surface)]"
+          >
+            +{domains.length - 8} more
+          </button>
+        )}
+      </div>
+      <!-- Desktop: vertical list -->
+      <div class="hidden md:block sticky top-24 space-y-1">
         {domains.map((domain, index) => (
           <button
             class="domain-item w-full text-left px-4 py-3 rounded-lg transition-all duration-200 hover:bg-[var(--color-surface)] border border-transparent data-[selected]:bg-[var(--color-surface)] data-[selected]:border-[var(--color-accent)]"
@@ -73,7 +97,7 @@ const domains = await getDomains();
             <!-- Sample books -->
             <div>
               <h3 class="text-sm font-medium text-[var(--color-text)] mb-3">Featured Books</h3>
-              <div class="grid grid-cols-5 gap-3">
+              <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
                 {domain.sample_books.slice(0, 5).map((book: any) => (
                   <a href={url(`/books/${book.id}`)} class="group">
                     <div class="aspect-[2/3] bg-[var(--color-bg)] rounded overflow-hidden mb-2">
@@ -117,9 +141,14 @@ const domains = await getDomains();
       item.addEventListener('click', () => {
         const domainId = item.getAttribute('data-domain-id');
 
-        // Update selected state
-        items.forEach(i => i.removeAttribute('data-selected'));
-        item.setAttribute('data-selected', 'true');
+        // Update selected state on ALL domain items (both mobile chips and desktop list)
+        items.forEach(i => {
+          if (i.getAttribute('data-domain-id') === domainId) {
+            i.setAttribute('data-selected', 'true');
+          } else {
+            i.removeAttribute('data-selected');
+          }
+        });
 
         // Show corresponding detail
         details.forEach(d => {
@@ -133,6 +162,23 @@ const domains = await getDomains();
     });
   }
 
+  // Mobile chips show more/less toggle
+  function initChipsToggle() {
+    const toggle = document.getElementById('mobile-chips-toggle');
+    if (!toggle) return;
+    const overflowChips = document.querySelectorAll('.mobile-chip-overflow');
+    let expanded = false;
+    toggle.addEventListener('click', () => {
+      expanded = !expanded;
+      overflowChips.forEach(chip => chip.classList.toggle('hidden', !expanded));
+      toggle.textContent = expanded ? 'Show less' : `+${overflowChips.length} more`;
+    });
+  }
+
   initDomainBrowser();
-  document.addEventListener('astro:page-load', initDomainBrowser);
+  initChipsToggle();
+  document.addEventListener('astro:page-load', () => {
+    initDomainBrowser();
+    initChipsToggle();
+  });
 </script>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -122,3 +122,12 @@ h1, h2, h3, h4 {
 ::-webkit-scrollbar-thumb:hover {
   background: var(--color-text-muted);
 }
+
+/* Hide scrollbar utility */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- Hamburger nav menu on mobile (<768px) for both BaseLayout and GalaxyLayout
- Galaxy sidebar becomes a bottom sheet (60vh) on phones with drag handle affordance
- Themes page stacks vertically on mobile with collapsible domain chips (+N more toggle)
- Responsive book grid (2→3→5 columns) and domain legend truncation on mobile

## Test plan
- [x] iPhone SE (375×667): hamburger, bottom sheet, wrapped chips, no clipping
- [x] iPhone 15 (390×844): same mobile patterns verified
- [x] iPad (820×1180): full desktop nav + two-column layouts
- [x] Desktop (1440×900): no regressions

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile-responsive design with device detection for navigation and UI components
  * Mobile navigation menu with hamburger toggle and integrated theme switching
  * Adaptive domain browser layout with chip-based display on mobile and vertical list on desktop
  * Responsive grid layouts for featured content across all screen sizes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->