### PR TITLE
feat: draggable bottom sheet on mobile universe page

### DIFF
--- a/web/src/components/GalaxyView.tsx
+++ b/web/src/components/GalaxyView.tsx
@@ -372,11 +372,18 @@ function Sidebar({
     el.addEventListener("touchstart", onTouchStart, { passive: true });
     el.addEventListener("touchmove", onTouchMove, { passive: false });
     el.addEventListener("touchend", onTouchEnd, { passive: true });
+    el.addEventListener("touchcancel", onTouchEnd, { passive: true });
     return () => {
       el.removeEventListener("touchstart", onTouchStart);
       el.removeEventListener("touchmove", onTouchMove);
       el.removeEventListener("touchend", onTouchEnd);
+      el.removeEventListener("touchcancel", onTouchEnd);
     };
+  }, [isMobile]);
+
+  // Reset sheet height when switching between mobile/desktop (e.g. rotation)
+  useEffect(() => {
+    setSheetHeight(DEFAULT_SHEET_HEIGHT);
   }, [isMobile]);
 
   const containerStyle: React.CSSProperties = isMobile


### PR DESCRIPTION
## Summary
- Mobile bottom sheet sidebar on the Universe page can now be dragged up and down via the handle bar
- Snaps to three positions: peek (20vh), half (40vh), and expanded (85vh)
- Default height reduced from 60vh to 40vh so more of the galaxy is visible on load
- Uses ref-based DOM event listeners with `{ passive: false }` to properly call `preventDefault()` on touchmove (React 18 marks touch handlers as passive by default)
- Smooth snap animation on release, no transition during active drag

## Test plan
- [ ] Test on iPhone SE (375px): drag handle up → sheet expands to 85vh, drag down → collapses to 20vh
- [ ] Test on iPhone 15 (390px): same drag behavior
- [ ] Test snap points: releasing between positions snaps to nearest (20%, 40%, 85%)
- [ ] Test desktop (1440px): sidebar unchanged (340px right panel, no drag handle)
- [ ] Verify no console errors related to passive event listeners

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive drag handle to the Sidebar on mobile devices, allowing users to easily resize the panel by dragging
  * Sheet height intelligently snaps to preset positions for optimal viewing and navigation
  * Improved touch interactions with enhanced responsiveness for smooth dragging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->