### PR TITLE
Clean up universe & community display

### DIFF
--- a/docs/libtrails_architecture.md
+++ b/docs/libtrails_architecture.md
@@ -1,0 +1,254 @@
+# LibTrails: Building a Topic Discovery Engine for 100 Classic Books
+
+LibTrails is a tool for discovering conceptual connections across a book collection. It parses EPUBs into text chunks, uses LLMs to extract granular topics from each chunk, generates semantic embeddings, and builds a multi-tier topic hierarchy — all stored locally in SQLite. The result is a searchable, browsable universe of ideas that connects Homer's *Iliad* to Dostoevsky's *Crime and Punishment* through shared concepts like guilt, duty, and divine justice.
+
+This post covers the architecture behind the demo at [libtrails.app](https://libtrails.app), running on a 100-book Project Gutenberg collection on a $3.50/month Lightsail t3.micro instance with 1 GB RAM.
+
+---
+
+## The Pipeline
+
+### Stage 1: Parse and Chunk
+
+EPUBs are parsed with [selectolax](https://github.com/rushter/selectolax) (HTML block tags converted to paragraph breaks) and recursively split into ~500-word chunks — first at paragraph boundaries, then sentences, then words as a last resort. The 100-book demo library produces **31,849 chunks**.
+
+### Stage 2: Two-Pass LLM Topic Extraction
+
+**Pass 1 — Book Themes (gemma3:27b):** A larger model reads the first few chunks plus Calibre metadata (tags, description, series) to extract 5–10 book-level themes in a single call. These themes anchor the next pass.
+
+**Pass 2 — Chunk Topics (gemma3:12b):** A smaller model extracts chunk-level topics, contextualized with the book themes from Pass 1. This produces domain-specific noun phrases instead of generic single words. The phrase "energy manipulation" from a fantasy novel stays distinct from "energy manipulation" in a psychology text because each extraction is grounded in the book's theme context.
+
+The two models run on separate machines: the 27b model on a MacBook Pro via LM Studio (MLX backend), the 12b model on a remote Windows PC with an RTX 3090 via LM Studio. This parallelizes extraction — while the 3090 grinds through chunks, the Mac processes the next book's themes.
+
+Result: **121,118 deduplicated topics** across 100 books.
+
+### Stage 3: Embed and Deduplicate
+
+All topics get 384-dimensional embeddings via [BGE-small-en-v1.5](https://huggingface.co/BAAI/bge-small-en-v1.5). A two-tier deduplication then merges near-duplicates:
+
+- **Cosine > 0.95**: merge unconditionally (clearly the same concept)
+- **Cosine 0.85–0.95**: merge only if both topics share at least one book — preventing cross-domain conflation
+
+This two-tier approach matters. Without the book-overlap guard, "energy manipulation" from a fantasy novel merges with the same phrase from a psychology text, losing the distinction that makes topic extraction useful.
+
+### Stage 4: Graph Construction
+
+A KNN graph is built from two types of edges:
+
+1. **Co-occurrence edges:** Topic pairs that appear in the same chunk get Pointwise Mutual Information (PMI) scores, weighted with a book-count boost: `PMI × (1 + log(1 + book_count))`. Only genuinely surprising co-occurrences make the cut (PMI ≥ 1.0).
+
+2. **Embedding-similarity edges:** Each topic's 10 nearest neighbors by cosine similarity (≥ 0.65) form additional edges.
+
+The KNN computation uses [FAISS-GPU](https://github.com/facebookresearch/faiss) on the RTX 3090 — 30 seconds for 837K vectors vs. 115 minutes on the MacBook CPU. Results are cached as `.npz` files so clustering reruns don't need GPU access.
+
+### Stage 5: Three-Tier Leiden Clustering
+
+**Hub removal:** High-degree topics (95th percentile) are removed before clustering. These generic terms (e.g., "conflict," "identity") would create artificially large, incoherent groups.
+
+**First Leiden pass — Topic Clusters (2,468):** The [Leiden algorithm](https://www.nature.com/articles/s41598-019-41695-z) runs with the CPM (Constant Potts Model) partition type at resolution 0.001, producing fine-grained clusters. Each cluster groups tightly related topics — "categorical imperative," "moral duty," and "Kantian ethics" all land in one cluster. The cluster label comes from its most representative topic: "Kantian Ethics & Moral Philosophy."
+
+**Second Leiden pass — Topic Communities (202):** The same graph with a coarser resolution groups clusters into broader communities — the browsable entries on the Topics page and the spheres in the Universe view. Each community is a coherent theme like "Victorian Social Norms" or "Ancient Greek Philosophy."
+
+**K-Means — Themes (26):** K-means groups cluster centroids into 26 high-level themes based on embedding similarity: "Adventure & Human Folly," "Literary Classics & Philosophy," "Nature & Rural Life," etc. Labels are LLM-generated and human-refined.
+
+### Stage 6: Universe Visualization
+
+Community centroids are projected into 3D with [UMAP](https://umap-learn.readthedocs.io/) (cosine metric, n_neighbors=15). Theme embeddings are mapped onto a single PCA axis, then each theme's position becomes a hue value — so semantically similar themes share similar colors. The result is rendered with [React Three Fiber](https://docs.pmnd.rs/react-three-fiber) using instanced meshes for performance.
+
+---
+
+## Lightweight Embeddings with ONNX Runtime
+
+The demo runs on a Lightsail t3.micro with 1 GB RAM. The naive approach — loading [sentence-transformers](https://sbert.net/) with PyTorch — pulls in ~300 MB of dependencies just for the embedding model. On a 1 GB instance, that's 30% of RAM burned before serving a single request, and the process regularly swaps to disk.
+
+### The Problem
+
+`sentence-transformers` depends on PyTorch, which is a 200+ MB library designed for GPU training. We don't need any of that for inference — we just need to run a single forward pass through a small transformer model to produce a 384-dim vector.
+
+### The Solution: ONNX Runtime
+
+[ONNX Runtime](https://onnxruntime.ai/) is Microsoft's optimized inference engine. It loads a pre-exported `.onnx` model file and runs inference with minimal dependencies — no PyTorch, no CUDA toolkit, no autograd. The relevant dependencies are:
+
+- `onnxruntime` (~15 MB) — the inference engine
+- `tokenizers` (~6 MB, from HuggingFace) — fast Rust-based tokenizer
+
+Total: ~20 MB vs. ~300 MB for sentence-transformers + PyTorch.
+
+### Exporting the Model
+
+A one-time export converts the sentence-transformers model to ONNX format using HuggingFace's [optimum](https://huggingface.co/docs/optimum/) library:
+
+```python
+from optimum.onnxruntime import ORTModelForFeatureExtraction
+from transformers import AutoTokenizer
+
+model = ORTModelForFeatureExtraction.from_pretrained(model_path, export=True)
+model.save_pretrained(onnx_output_dir)
+
+tokenizer = AutoTokenizer.from_pretrained(model_path)
+tokenizer.save_pretrained(onnx_output_dir)
+```
+
+The exported model is ~33 MB. It gets SCP'd to the server alongside the tokenizer files.
+
+### Dual Backend Architecture
+
+The embedding module (`embeddings.py`) auto-detects which backend to use:
+
+1. Check if `models/bge-small-onnx/model.onnx` exists and `onnxruntime` is installed → use ONNX
+2. Otherwise → fall back to sentence-transformers
+
+Both backends produce **identical embeddings** (verified: cosine similarity = 1.000000 between outputs). The ONNX path uses CLS pooling with L2 normalization, matching BGE's default strategy:
+
+```python
+def _onnx_encode(texts: list[str]) -> np.ndarray:
+    encodings = _onnx_tokenizer.encode_batch(texts)
+
+    input_ids = np.array([e.ids for e in encodings], dtype=np.int64)
+    attention_mask = np.array([e.attention_mask for e in encodings], dtype=np.int64)
+    token_type_ids = np.array([e.type_ids for e in encodings], dtype=np.int64)
+
+    outputs = _onnx_session.run(None, {
+        "input_ids": input_ids,
+        "attention_mask": attention_mask,
+        "token_type_ids": token_type_ids,
+    })
+
+    # CLS pooling (index 0)
+    cls_embeddings = outputs[0][:, 0, :]
+
+    # L2 normalize
+    norms = np.linalg.norm(cls_embeddings, axis=1, keepdims=True)
+    return cls_embeddings / np.maximum(norms, 1e-12)
+```
+
+The `get_model()` function still loads sentence-transformers for bulk operations (indexing on a dev machine), without overriding the active backend — so `embed_text()` and `embed_texts()` continue using ONNX for server requests even if sentence-transformers gets loaded for a batch job.
+
+### Impact
+
+| Metric | sentence-transformers | ONNX Runtime |
+|--------|----------------------|--------------|
+| Process RSS | ~500 MB | ~200 MB |
+| Model load time | ~3s | ~0.5s |
+| Embedding latency | ~15ms/query | ~12ms/query |
+| PyTorch required | Yes (~200 MB) | No |
+| Swap pressure (1 GB RAM) | Frequent | None |
+
+The server now starts in under a second and stays well within the 1 GB memory budget with room for SQLite page cache, ONNX inference, and the Astro SSR process.
+
+---
+
+## Optimizing Hybrid Search for a $3.50 Server
+
+The initial hybrid search implementation was designed on a MacBook Pro where every query ran in ~200ms. Deployed to the Lightsail t3.micro, things looked different.
+
+### The Original Design: 7-Signal Book Search
+
+Book search originally fused seven independent retrieval signals via [Reciprocal Rank Fusion](https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf) (RRF):
+
+1. **FTS5 book metadata** — keyword search over title, author, description
+2. **FTS5 topic labels** — keyword search across 121K topic labels, mapped back to books
+3. **FTS5 chunk text** — keyword search across 31,849 chunk passages, mapped back to books
+4. **Semantic topic vectors** — cosine similarity against 121K topic embeddings via sqlite-vec
+5. **Semantic book theme vectors** — cosine similarity against book-level theme embeddings
+6. **Semantic book vectors** — cosine similarity against whole-book embeddings
+7. **Semantic chunk vectors** — cosine similarity against 31,849 chunk embeddings, best per book
+
+RRF combines these by scoring each result as `1/(k + rank)` across all lists, where `k=60`. A book that ranks #1 in keyword search and #5 in semantic search scores higher than one that ranks #2 in both — rewarding results that excel in at least one signal.
+
+Cluster search similarly used 5 signals: topic FTS, **semantic topic vectors**, cluster label matching, chunk FTS, and chunk semantics.
+
+### The Bottleneck: 121K Vector Scan
+
+Profiling on the server revealed that **signal 4 (semantic topic vectors) took 2.7 seconds per query**. sqlite-vec performs exact KNN — it scans all 121,000 topic vectors and computes cosine distance against each one. On a single-core t3.micro, that's a lot of floating-point math.
+
+The other vector signals were fast because they searched much smaller tables:
+
+| Table | Rows | Scan time |
+|-------|------|-----------|
+| `topic_vectors` | 121,118 | **2.7s** |
+| `chunk_vectors` | 31,849 | ~0.5s |
+| `book_theme_vectors` | ~800 | ~0.01s |
+| `book_vectors` | 100 | ~0.005s |
+
+The chunk vectors (31K rows, ~0.5s) already provided equivalent semantic coverage to the topic vectors — every chunk that mentions a concept will have a nearby embedding, and the chunk→book mapping captures the same books that topic→book would. The topic vector signal was redundant given the chunk signal, but 5x more expensive.
+
+### The Fix: Drop to 6 Signals
+
+Removing the topic vector scan from both search paths:
+
+- **Book search**: 7 signals → 6 (drop signal 4)
+- **Cluster search**: 5 signals → 4 (drop topic vector signal)
+
+Total search time dropped from ~3.5s to ~0.8s with no measurable difference in result quality — the chunk and theme vectors already cover the same semantic ground.
+
+### Related Books: From 19 Seconds to 50 Milliseconds
+
+The `find_related_books` endpoint (shown on every book detail page) was even worse. The original implementation called `hybrid_search_books` with a query constructed from the book's title, author, and all themes — a 373-character query with 50+ tokens. Every FTS5 query matched nearly everything, and the topic vector scan ran on top of that. Total: **19 seconds per request**.
+
+The rewrite uses only the fast vector signals:
+
+```python
+def find_related_books(conn, book_id, limit=12):
+    # Build a short embedding query from title + top themes
+    query = f"{title} by {author}. {', '.join(themes[:5])}"
+    query_bytes = embedding_to_bytes(embed_text(query))
+
+    # 3 fast signals only (~0.05s total)
+    book_direct = _semantic_search_books_direct(conn, query, query_bytes=query_bytes)   # 100 rows
+    theme_books = _semantic_search_book_themes(conn, query, query_bytes=query_bytes)     # ~800 rows
+    fts_books = _fts_search_books(conn, title)                                          # FTS on 100 books
+
+    return rrf_fuse([book_direct, theme_books, fts_books])
+```
+
+Three signals over small tables: **50ms total**. The quality is arguably better — the old approach produced noisy results because the over-long FTS query matched too broadly.
+
+### What Was Compromised
+
+The topic vector signal *did* add value for certain queries — particularly abstract concept searches like "existentialism" or "manifest destiny" where the relevant topics might not appear in chunk text verbatim. But the chunk embeddings capture these concepts well enough (the chunks *about* existentialism have nearby embeddings even if the word doesn't appear), and the 5x speedup on every single query is worth the marginal quality loss on edge cases.
+
+If we move to a larger server or add approximate nearest neighbor (ANN) indexing, we could add the signal back. But for a $3.50/month t3.micro, 0.8s search is the right tradeoff.
+
+---
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|------------|
+| Topic extraction | gemma3 via Ollama / Gemini / LM Studio |
+| Embeddings | BGE-small-en-v1.5 (384 dims) via ONNX Runtime |
+| Search | Hybrid: FTS5 (BM25) + sqlite-vec (cosine) + RRF fusion |
+| Clustering | Leiden (python-igraph + leidenalg), two-pass |
+| 3D projection | UMAP + PCA semantic colors |
+| Backend | FastAPI + SQLite |
+| Frontend | Astro + React Three Fiber |
+| Hosting | AWS Lightsail t3.micro (1 GB RAM, $3.50/month) |
+| Reverse proxy | Caddy (auto TLS) |
+
+---
+
+## Numbers
+
+| Metric | Value |
+|--------|-------|
+| Books | 100 (Project Gutenberg classics, ~800 BC – 1925 AD) |
+| Text chunks | 31,849 |
+| Extracted topics | 121,118 |
+| Leiden clusters | 2,468 |
+| Topic communities | 202 |
+| Themes | 26 |
+| Search signals (books) | 6 |
+| Search signals (clusters) | 4 |
+| Server memory budget | 1 GB |
+| API process RSS | ~200 MB (with ONNX) |
+| Search latency | ~0.8s (was ~3.5s) |
+| Related books latency | ~0.05s (was ~19s) |
+
+---
+
+## Links
+
+- **Live demo**: [libtrails.app](https://libtrails.app)
+- **Source**: [github.com/seaberger/libtrails](https://github.com/seaberger/libtrails)
+- **Inspiration**: [Pieter Maes' "Reading Across Books"](https://pieterma.es/syntopic-reading-claude/) and the [Trails visualization](https://trails.pieterma.es)

--- a/src/libtrails/api/routers/communities.py
+++ b/src/libtrails/api/routers/communities.py
@@ -47,6 +47,14 @@ def list_communities(
 
     rows = cursor.fetchall()
 
+    # Pre-fetch cluster counts per community
+    cursor.execute("""
+        SELECT community_id, COUNT(*) as cluster_count
+        FROM cluster_communities
+        GROUP BY community_id
+    """)
+    cluster_counts = {r["community_id"]: r["cluster_count"] for r in cursor.fetchall()}
+
     result = []
     for row in rows:
         sample_books_raw = json.loads(row["sample_books_json"] or "[]")
@@ -57,6 +65,7 @@ def list_communities(
                 community_id=row["community_id"],
                 label=row["label"],
                 topic_count=row["topic_count"],
+                cluster_count=cluster_counts.get(row["community_id"], 0),
                 book_count=row["book_count"] or 0,
                 primary_book_count=row["primary_book_count"] or 0,
                 domain_id=row["domain_id"],

--- a/src/libtrails/api/routers/search.py
+++ b/src/libtrails/api/routers/search.py
@@ -256,6 +256,23 @@ def hybrid_search(
 
     elif scope == "communities":
         raw = hybrid_search_communities(db, q, limit)
+
+        # Pre-fetch cluster counts for all matched communities
+        community_ids = [r["community_id"] for r in raw]
+        cluster_counts: dict[int, int] = {}
+        if community_ids:
+            placeholders = ",".join("?" * len(community_ids))
+            rows = db.execute(
+                f"""
+                SELECT community_id, COUNT(*) as cnt
+                FROM cluster_communities
+                WHERE community_id IN ({placeholders})
+                GROUP BY community_id
+                """,
+                community_ids,
+            ).fetchall()
+            cluster_counts = {r["community_id"]: r["cnt"] for r in rows}
+
         community_results = []
         for r in raw:
             sample_books = []
@@ -269,6 +286,7 @@ def hybrid_search(
                     community_id=r["community_id"],
                     label=r["label"],
                     topic_count=r["topic_count"],
+                    cluster_count=cluster_counts.get(r["community_id"], 0),
                     book_count=r["book_count"],
                     score=r["score"],
                     sample_books=sample_books,

--- a/src/libtrails/api/schemas.py
+++ b/src/libtrails/api/schemas.py
@@ -141,6 +141,7 @@ class CommunitySummary(BaseModel):
     community_id: int
     label: str
     topic_count: int
+    cluster_count: int = 0
     book_count: int
     primary_book_count: int = 0
     domain_id: int | None = None
@@ -180,6 +181,8 @@ class UniverseCommunity(BaseModel):
     x: float
     y: float
     z: float
+    cluster_count: int = 0
+    top_clusters: list[str] = []
     top_topics: list[str] = []
 
 

--- a/src/libtrails/api/schemas.py
+++ b/src/libtrails/api/schemas.py
@@ -232,6 +232,7 @@ class HybridCommunityResult(BaseModel):
     community_id: int
     label: str
     topic_count: int
+    cluster_count: int = 0
     book_count: int
     score: float
     sample_books: list[BookSummary] = []

--- a/src/libtrails/config.py
+++ b/src/libtrails/config.py
@@ -181,5 +181,8 @@ TOPIC_STOPLIST = frozenset(
     }
 )
 
-# Universe visualization
-UNIVERSE_JSON_PATH = DATA_DIR / "universe_coords.json"
+# Universe visualization — keyed per DB variant
+if _db_variant:
+    UNIVERSE_JSON_PATH = DATA_DIR / f"universe_coords_{_db_variant}.json"
+else:
+    UNIVERSE_JSON_PATH = DATA_DIR / "universe_coords.json"

--- a/src/libtrails/universe.py
+++ b/src/libtrails/universe.py
@@ -150,12 +150,16 @@ def generate_universe_data(
     # Pre-fetch cluster counts and top cluster labels per community
     cluster_info: dict[int, dict] = {}
     cursor.execute("""
-        SELECT cc.community_id,
+        SELECT community_id,
                COUNT(*) as cluster_count,
-               GROUP_CONCAT(cs.top_label, '||') as cluster_labels
-        FROM cluster_communities cc
-        JOIN cluster_stats cs ON cs.cluster_id = cc.cluster_id
-        GROUP BY cc.community_id
+               GROUP_CONCAT(top_label, '||') as cluster_labels
+        FROM (
+            SELECT cc.community_id, cs.top_label
+            FROM cluster_communities cc
+            JOIN cluster_stats cs ON cs.cluster_id = cc.cluster_id
+            ORDER BY cc.community_id, cs.book_count DESC
+        )
+        GROUP BY community_id
     """)
     for row in cursor.fetchall():
         labels_raw = row["cluster_labels"] or ""

--- a/src/libtrails/universe.py
+++ b/src/libtrails/universe.py
@@ -147,6 +147,24 @@ def generate_universe_data(
     """)
     communities = cursor.fetchall()
 
+    # Pre-fetch cluster counts and top cluster labels per community
+    cluster_info: dict[int, dict] = {}
+    cursor.execute("""
+        SELECT cc.community_id,
+               COUNT(*) as cluster_count,
+               GROUP_CONCAT(cs.top_label, '||') as cluster_labels
+        FROM cluster_communities cc
+        JOIN cluster_stats cs ON cs.cluster_id = cc.cluster_id
+        GROUP BY cc.community_id
+    """)
+    for row in cursor.fetchall():
+        labels_raw = row["cluster_labels"] or ""
+        labels = [lbl for lbl in labels_raw.split("||") if lbl][:8]
+        cluster_info[row["community_id"]] = {
+            "cluster_count": row["cluster_count"],
+            "top_clusters": labels,
+        }
+
     # Compute community centroids (average of child cluster centroids)
     community_data = []
     centroids = []
@@ -163,6 +181,7 @@ def generate_universe_data(
             domain_id = row["domain_id"] if row["domain_id"] is not None else -1
             domain_label = row["domain_label"] or "Unknown"
 
+            ci = cluster_info.get(community_id, {})
             community_data.append(
                 {
                     "community_id": community_id,
@@ -172,6 +191,8 @@ def generate_universe_data(
                     "book_ids": book_ids,
                     "domain_id": domain_id,
                     "domain_label": domain_label,
+                    "cluster_count": ci.get("cluster_count", 0),
+                    "top_clusters": ci.get("top_clusters", []),
                     "top_topics": top_topics,
                 }
             )

--- a/web/src/components/GalaxyView.tsx
+++ b/web/src/components/GalaxyView.tsx
@@ -633,11 +633,6 @@ function MultiSelectPanel({
     return ids;
   }, [communities]);
 
-  const totalTopics = useMemo(
-    () => communities.reduce((sum, c) => sum + c.size, 0),
-    [communities]
-  );
-
   // Domain breakdown: group communities by domain, sorted by count desc
   const domainBreakdown = useMemo(() => {
     const counts = new Map<number, number>();
@@ -669,11 +664,11 @@ function MultiSelectPanel({
       .map(([id]) => id);
   }, [communities]);
 
-  // Top topics: aggregate top_topics across communities, count frequency
-  const topTopics = useMemo(() => {
+  // Top clusters: aggregate top_clusters across communities, count frequency
+  const topClusters = useMemo(() => {
     const freq = new Map<string, number>();
     for (const c of communities) {
-      for (const t of c.top_topics) {
+      for (const t of c.top_clusters) {
         freq.set(t, (freq.get(t) || 0) + 1);
       }
     }
@@ -747,8 +742,8 @@ function MultiSelectPanel({
       >
         {[
           `${uniqueBookIds.size} books`,
-          `${totalTopics} topics`,
-          `${domainBreakdown.length} domains`,
+          `${communities.reduce((sum, c) => sum + c.cluster_count, 0)} clusters`,
+          `${domainBreakdown.length} themes`,
         ].map((label) => (
           <span
             key={label}
@@ -777,7 +772,7 @@ function MultiSelectPanel({
               marginBottom: 6,
             }}
           >
-            Domain Breakdown
+            Theme Breakdown
           </div>
           {/* Stacked bar */}
           <div
@@ -797,7 +792,7 @@ function MultiSelectPanel({
                   background: domain?.color || "#555",
                   minWidth: 2,
                 }}
-                title={`${domain?.label || `Domain ${domainId}`}: ${count} topics`}
+                title={`${domain?.label || `Theme ${domainId}`}: ${count} communities`}
               />
             ))}
           </div>
@@ -823,10 +818,10 @@ function MultiSelectPanel({
                   }}
                 />
                 <span style={{ color: colors.text, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                  {domain?.label || `Domain ${domainId}`}
+                  {domain?.label || `Theme ${domainId}`}
                 </span>
                 <span style={{ color: colors.textMuted, fontSize: "0.65rem", flexShrink: 0 }}>
-                  {count} topics
+                  {count}
                 </span>
               </div>
             ))}
@@ -924,8 +919,8 @@ function MultiSelectPanel({
         )}
       </div>
 
-      {/* ── 4. Top Topics ── */}
-      {topTopics.length > 0 && (
+      {/* ── 4. Top Clusters ── */}
+      {topClusters.length > 0 && (
         <div style={{ marginBottom: 16 }}>
           <div
             style={{
@@ -936,12 +931,12 @@ function MultiSelectPanel({
               marginBottom: 6,
             }}
           >
-            Top Topics
+            Top Clusters
           </div>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
-            {topTopics.map(([topic, count]) => (
+            {topClusters.map(([cluster, count]) => (
               <span
-                key={topic}
+                key={cluster}
                 style={{
                   background: colors.chipBgHover,
                   borderRadius: 4,
@@ -950,7 +945,7 @@ function MultiSelectPanel({
                   color: colors.text,
                 }}
               >
-                {topic}
+                {cluster}
                 {count > 1 && (
                   <span style={{ color: colors.textMuted, marginLeft: 4, fontSize: "0.6rem" }}>
                     ×{count}
@@ -1142,11 +1137,11 @@ function CommunityPanel({
       >
         <span>{community.book_count} books</span>
         <span>·</span>
-        <span>{community.size} topics</span>
+        <span>{community.cluster_count} clusters</span>
       </div>
 
-      {/* Top topics */}
-      {community.top_topics.length > 0 && (
+      {/* Cluster labels */}
+      {community.top_clusters.length > 0 && (
         <div style={{ marginBottom: 16 }}>
           <div
             style={{
@@ -1157,10 +1152,10 @@ function CommunityPanel({
               marginBottom: 6,
             }}
           >
-            Top Topics
+            Clusters
           </div>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
-            {community.top_topics.slice(0, 8).map((t) => (
+            {community.top_clusters.slice(0, 8).map((t) => (
               <span
                 key={t}
                 style={{
@@ -1223,42 +1218,6 @@ function CommunityPanel({
         </div>
       )}
 
-      {/* Clusters from detail */}
-      {detail && detail.clusters.length > 0 && (
-        <div style={{ marginBottom: 16 }}>
-          <div
-            style={{
-              fontSize: "0.65rem",
-              textTransform: "uppercase",
-              letterSpacing: "0.05em",
-              color: colors.textMuted,
-              marginBottom: 6,
-            }}
-          >
-            Clusters ({detail.clusters.length})
-          </div>
-          <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
-            {detail.clusters.slice(0, 12).map((cl) => (
-              <span
-                key={cl.cluster_id}
-                style={{
-                  background: colors.chipBg,
-                  borderRadius: 4,
-                  padding: "2px 7px",
-                  fontSize: "0.65rem",
-                  color: colors.textMuted,
-                }}
-              >
-                {cl.label}
-                <span style={{ color: colors.textFaint, marginLeft: 4 }}>
-                  {cl.size}
-                </span>
-              </span>
-            ))}
-          </div>
-        </div>
-      )}
-
       {/* Explore link */}
       <a
         href={`${basePath}/communities/${community.community_id}`}
@@ -1314,7 +1273,7 @@ function DomainLegend({
           alignItems: "center",
         }}
       >
-        <span>Domains</span>
+        <span>Themes</span>
         {activeDomains && (
           <button
             onClick={onClear}
@@ -1381,7 +1340,7 @@ function DomainLegend({
             padding: "6px 0",
           }}
         >
-          +{hiddenCount} more domains
+          +{hiddenCount} more themes
         </button>
       )}
       {isMobile && expanded && hiddenCount > 0 && (
@@ -1859,11 +1818,11 @@ export default function GalaxyView() {
               marginBottom: "6px",
             }}
           >
-            {tooltip.community.book_count} books &middot; {tooltip.community.size} topics
+            {tooltip.community.book_count} books &middot; {tooltip.community.cluster_count} clusters
           </div>
-          {tooltip.community.top_topics.length > 0 && (
+          {tooltip.community.top_clusters.length > 0 && (
             <div style={{ display: "flex", flexWrap: "wrap", gap: "4px" }}>
-              {tooltip.community.top_topics.slice(0, 4).map((t) => (
+              {tooltip.community.top_clusters.slice(0, 4).map((t) => (
                 <span
                   key={t}
                   style={{

--- a/web/src/components/GalaxyView.tsx
+++ b/web/src/components/GalaxyView.tsx
@@ -668,7 +668,7 @@ function MultiSelectPanel({
   const topClusters = useMemo(() => {
     const freq = new Map<string, number>();
     for (const c of communities) {
-      for (const t of c.top_clusters) {
+      for (const t of (c.top_clusters ?? [])) {
         freq.set(t, (freq.get(t) || 0) + 1);
       }
     }
@@ -1141,7 +1141,7 @@ function CommunityPanel({
       </div>
 
       {/* Cluster labels */}
-      {community.top_clusters.length > 0 && (
+      {(community.top_clusters ?? []).length > 0 && (
         <div style={{ marginBottom: 16 }}>
           <div
             style={{
@@ -1155,7 +1155,7 @@ function CommunityPanel({
             Clusters
           </div>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
-            {community.top_clusters.slice(0, 8).map((t) => (
+            {(community.top_clusters ?? []).slice(0, 8).map((t) => (
               <span
                 key={t}
                 style={{
@@ -1820,9 +1820,9 @@ export default function GalaxyView() {
           >
             {tooltip.community.book_count} books &middot; {tooltip.community.cluster_count} clusters
           </div>
-          {tooltip.community.top_clusters.length > 0 && (
+          {(tooltip.community.top_clusters ?? []).length > 0 && (
             <div style={{ display: "flex", flexWrap: "wrap", gap: "4px" }}>
-              {tooltip.community.top_clusters.slice(0, 4).map((t) => (
+              {(tooltip.community.top_clusters ?? []).slice(0, 4).map((t) => (
                 <span
                   key={t}
                   style={{

--- a/web/src/components/ThemeCard.astro
+++ b/web/src/components/ThemeCard.astro
@@ -64,7 +64,7 @@ const bookCount = stackBooks.length;
     {theme.label}
   </h3>
   <p class="text-xs text-[var(--color-text-muted)] text-center">
-    {theme.book_count} books · {theme.size} topics
+    {theme.book_count} books · {theme.size} clusters
   </p>
 </a>
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -101,6 +101,7 @@ export interface CommunitySummary {
   community_id: number;
   label: string;
   topic_count: number;
+  cluster_count: number;
   book_count: number;
   primary_book_count: number;
   domain_id: number | null;
@@ -134,6 +135,8 @@ export interface UniverseCommunity {
   x: number;
   y: number;
   z: number;
+  cluster_count: number;
+  top_clusters: string[];
   top_topics: string[];
 }
 

--- a/web/src/pages/about/index.astro
+++ b/web/src/pages/about/index.astro
@@ -102,7 +102,7 @@ import { url } from '../../lib/url';
           ["2,468", "Leiden clusters"],
           ["202", "Topic communities"],
           ["26", "Themes"],
-          ["7", "Search signals"],
+          ["6", "Search signals"],
         ].map(([value, label]) => (
           <div class="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg px-4 py-3 text-center">
             <div class="text-lg font-medium text-[var(--color-text)]">{value}</div>
@@ -163,15 +163,22 @@ import { url } from '../../lib/url';
             High-degree "hub" topics (95th percentile) are removed before clustering — these generic terms
             would create artificially large, incoherent groups. The Leiden algorithm then runs with the
             CPM (Constant Potts Model) partition type at resolution 0.001, producing 2,468 fine-grained
-            topic clusters. These clusters power the semantic search engine — topic and chunk vectors are
-            indexed in sqlite-vec for fast cosine similarity lookups, and full-text search (FTS5) indexes
-            the cluster labels, topic labels, and chunk text for keyword matching.
+            topic clusters. Each cluster groups topics that are tightly related — for example, "categorical imperative,"
+            "moral duty," and "Kantian ethics" all land in one cluster. The cluster's label is drawn from its most
+            representative topic, so you see names like "Kantian Ethics &amp; Moral Philosophy" rather than raw topic strings.
+          </p>
+          <p class="text-sm mt-2">
+            These are the labeled chips you see throughout the app — on topic detail pages, in universe popups, and
+            in search results. When a topic page shows "27 clusters," that means 27 distinct sub-themes make up that
+            broader topic community. Clusters also power the search engine: topic and chunk vectors are indexed in
+            sqlite-vec for cosine similarity lookups, and FTS5 indexes cluster labels, topic labels, and chunk text
+            for keyword matching.
           </p>
         </div>
         <div class="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg p-5">
           <h4 class="text-sm font-medium text-[var(--color-text)] mb-2">Second Leiden Pass: Topic Communities</h4>
           <p class="text-sm">
-            A second Leiden pass runs on the same topic graph with a different resolution, grouping topics
+            A second Leiden pass runs on the same topic graph with a different resolution, grouping clusters
             into 202 broader communities. These are the browsable entries on the
             <a href={url("/communities")} class="text-[var(--color-accent)] hover:underline">Topics</a> page
             and the spheres in the
@@ -207,6 +214,48 @@ import { url } from '../../lib/url';
       </div>
     </section>
 
+    <!-- Reading the UI -->
+    <section>
+      <h2 class="text-lg font-medium text-[var(--color-text)] mb-3">Reading the UI</h2>
+      <p class="text-[var(--color-text-muted)] mb-4">
+        The pipeline produces a three-tier hierarchy. Here's how each level maps to what you see:
+      </p>
+      <div class="space-y-3 text-[var(--color-text-muted)]">
+        <div class="flex items-start gap-3">
+          <div class="flex-shrink-0 w-20 text-right">
+            <span class="text-xs font-medium text-[var(--color-accent)] uppercase tracking-wide">Clusters</span>
+          </div>
+          <p class="text-sm">
+            The labeled chips on topic pages and universe popups. Each chip names a tight group of related topics
+            (e.g., "Kantian Ethics &amp; Moral Philosophy"). When a topic card shows "27 clusters," those are its
+            27 distinct sub-themes. Clusters are the finest granularity exposed in the UI.
+          </p>
+        </div>
+        <div class="flex items-start gap-3">
+          <div class="flex-shrink-0 w-20 text-right">
+            <span class="text-xs font-medium text-[var(--color-accent)] uppercase tracking-wide">Topics</span>
+          </div>
+          <p class="text-sm">
+            The cards on the <a href={url("/communities")} class="text-[var(--color-accent)] hover:underline">Topics</a> page
+            and the spheres in the <a href={url("/")} class="text-[var(--color-accent)] hover:underline">Universe</a>.
+            Each topic is a community of clusters spanning multiple books — broad enough to be interesting
+            ("Victorian Social Norms," "Ancient Greek Philosophy") but specific enough to be coherent.
+          </p>
+        </div>
+        <div class="flex items-start gap-3">
+          <div class="flex-shrink-0 w-20 text-right">
+            <span class="text-xs font-medium text-[var(--color-accent)] uppercase tracking-wide">Themes</span>
+          </div>
+          <p class="text-sm">
+            The color-coded groupings on the <a href={url("/themes")} class="text-[var(--color-accent)] hover:underline">Themes</a> page
+            and the universe legend. Each theme aggregates many topics into a high-level category like
+            "Adventure &amp; Human Folly" or "Nature &amp; Rural Life." Themes determine sphere colors in the universe —
+            similar themes get similar hues.
+          </p>
+        </div>
+      </div>
+    </section>
+
     <!-- Search -->
     <section>
       <h2 class="text-lg font-medium text-[var(--color-text)] mb-3">Hybrid Search</h2>
@@ -217,10 +266,10 @@ import { url } from '../../lib/url';
       </p>
       <div class="space-y-4 text-[var(--color-text-muted)]">
         <div class="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg p-5">
-          <h4 class="text-sm font-medium text-[var(--color-text)] mb-2">7-Signal Book Search</h4>
+          <h4 class="text-sm font-medium text-[var(--color-text)] mb-2">Hybrid Book Search</h4>
           <p class="text-sm mb-3">
             When you search on the <a href={url("/books")} class="text-[var(--color-accent)] hover:underline">Books</a>
-            page, your query is evaluated against seven independent retrieval signals, each producing its own ranked list:
+            page, your query is evaluated against six independent retrieval signals, each producing its own ranked list:
           </p>
           <ul class="space-y-1.5 text-sm">
             <li class="flex items-start gap-2">
@@ -237,23 +286,19 @@ import { url } from '../../lib/url';
             </li>
             <li class="flex items-start gap-2">
               <span class="text-[var(--color-accent)] mt-0.5 flex-shrink-0 font-medium">4.</span>
-              <span><strong class="text-[var(--color-text)]">Semantic topic vectors</strong> — cosine similarity against topic embeddings via sqlite-vec</span>
-            </li>
-            <li class="flex items-start gap-2">
-              <span class="text-[var(--color-accent)] mt-0.5 flex-shrink-0 font-medium">5.</span>
               <span><strong class="text-[var(--color-text)]">Semantic book theme vectors</strong> — cosine similarity against book-level theme embeddings</span>
             </li>
             <li class="flex items-start gap-2">
-              <span class="text-[var(--color-accent)] mt-0.5 flex-shrink-0 font-medium">6.</span>
+              <span class="text-[var(--color-accent)] mt-0.5 flex-shrink-0 font-medium">5.</span>
               <span><strong class="text-[var(--color-text)]">Semantic book vectors</strong> — cosine similarity against whole-book embeddings (title + themes)</span>
             </li>
             <li class="flex items-start gap-2">
-              <span class="text-[var(--color-accent)] mt-0.5 flex-shrink-0 font-medium">7.</span>
+              <span class="text-[var(--color-accent)] mt-0.5 flex-shrink-0 font-medium">6.</span>
               <span><strong class="text-[var(--color-text)]">Semantic chunk vectors</strong> — cosine similarity against chunk embeddings, best per book</span>
             </li>
           </ul>
           <p class="text-sm text-[var(--color-text-muted)] mt-3">
-            Each result shows a colored badge indicating which signal contributed most: keyword, content, topic, theme, book, semantic, or chunk.
+            Each result shows a colored badge indicating which signal contributed most: keyword, topic, content, theme, book, or chunk.
           </p>
         </div>
         <div class="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg p-5">
@@ -271,9 +316,9 @@ import { url } from '../../lib/url';
           <h4 class="text-sm font-medium text-[var(--color-text)] mb-2">Scope-Aware Search</h4>
           <p class="text-sm">
             Search adapts to each page. On <a href={url("/books")} class="text-[var(--color-accent)] hover:underline">Books</a>,
-            all 7 signals rank books directly. On
+            all 6 signals rank books directly. On
             <a href={url("/communities")} class="text-[var(--color-accent)] hover:underline">Topics</a>,
-            5 signals surface the most relevant topic communities — topic FTS/semantic, cluster label matching, and chunk FTS/semantic.
+            4 signals surface the most relevant topic communities — topic FTS, cluster label matching, and chunk FTS/semantic.
             On <a href={url("/themes")} class="text-[var(--color-accent)] hover:underline">Themes</a>,
             topic scores roll up to highlight matching themes, with a boost for direct label matches.
           </p>
@@ -282,7 +327,7 @@ import { url } from '../../lib/url';
           <h4 class="text-sm font-medium text-[var(--color-text)] mb-2">Universe Search</h4>
           <p class="text-sm">
             The <a href={url("/")} class="text-[var(--color-accent)] hover:underline">Universe</a> search bar
-            runs the same 5-signal community search, then aggregates results by community. Matching communities glow
+            runs the same cluster search, then aggregates results by community. Matching communities glow
             amber in the 3D view — the brighter the glow, the stronger the match — with a ranked sidebar list showing
             the top hits. This lets you visually see where a concept lives in the semantic landscape and which
             neighboring communities are related.
@@ -304,7 +349,7 @@ import { url } from '../../lib/url';
           <h4 class="text-sm font-medium text-[var(--color-text)] mb-2">Navigation</h4>
           <p class="text-sm">
             Drag to rotate, scroll to zoom, and right-drag to pan. Each sphere is a topic community —
-            larger spheres contain more topics. Colors encode themes: semantically similar themes share similar hues,
+            larger spheres span more books. Colors encode themes: semantically similar themes share similar hues,
             so you can see natural neighborhoods form in 3D space.
           </p>
         </div>
@@ -312,7 +357,7 @@ import { url } from '../../lib/url';
           <h4 class="text-sm font-medium text-[var(--color-text)] mb-2">Interacting</h4>
           <p class="text-sm">
             Hover over a sphere to see its label and the books it spans. Click to open a detail panel with the
-            community's top topics and all contributing books. Use the search bar to light up matching communities —
+            community's cluster labels and all contributing books. Use the search bar to light up matching communities —
             try searching for a concept like "justice" or "natural selection" to see which corners of the library
             discuss it.
           </p>
@@ -337,7 +382,7 @@ import { url } from '../../lib/url';
           ["Two-Pass Extraction", "Book themes from a 27b model contextualize chunk-level topic extraction by a 12b model"],
           ["Multi-Provider LLM", "Ollama, Gemini API, or LM Studio — swap with a CLI flag"],
           ["3D Universe", "Interactive Three.js galaxy with 202 topic communities, colored by semantic theme similarity"],
-          ["7-Signal Hybrid Search", "FTS5 keyword + semantic vector search across books, topics, themes, and chunks, fused via RRF"],
+          ["Hybrid Search", "FTS5 keyword + semantic vector search across books, themes, and chunks, fused via Reciprocal Rank Fusion"],
           ["Smart Deduplication", "Two-tier merging: cosine >0.95 merges always, 0.85–0.95 only if same book — prevents cross-domain conflation"],
           ["Three-Tier Hierarchy", "Leiden clusters (2,468, with hub removal) → topic communities (202) → themes (26)"],
         ].map(([title, desc]) => (
@@ -357,7 +402,7 @@ import { url } from '../../lib/url';
           <tbody>
             {[
               ["Topic extraction", "gemma3 via Ollama / Gemini / LM Studio"],
-              ["Embeddings", "BGE-small-en-v1.5 (384 dims)"],
+              ["Embeddings", "BGE-small-en-v1.5 (384 dims) via ONNX Runtime"],
               ["Search", "Hybrid: FTS5 (BM25) + sqlite-vec (cosine) + RRF fusion"],
               ["Clustering", "Leiden (python-igraph + leidenalg), two-pass"],
               ["3D projection", "UMAP + PCA semantic colors"],

--- a/web/src/pages/about/index.astro
+++ b/web/src/pages/about/index.astro
@@ -318,7 +318,7 @@ import { url } from '../../lib/url';
             Search adapts to each page. On <a href={url("/books")} class="text-[var(--color-accent)] hover:underline">Books</a>,
             all 6 signals rank books directly. On
             <a href={url("/communities")} class="text-[var(--color-accent)] hover:underline">Topics</a>,
-            4 signals surface the most relevant topic communities — topic FTS, cluster label matching, and chunk FTS/semantic.
+            4 signals surface the most relevant topic communities — topic FTS, cluster label matching, chunk FTS, and chunk semantic.
             On <a href={url("/themes")} class="text-[var(--color-accent)] hover:underline">Themes</a>,
             topic scores roll up to highlight matching themes, with a boost for direct label matches.
           </p>

--- a/web/src/pages/communities/[id].astro
+++ b/web/src/pages/communities/[id].astro
@@ -36,7 +36,7 @@ try {
       {community.label}
     </h1>
     <p class="text-[var(--color-text-muted)] mb-4">
-      {community.books.length} books · {community.topic_count} topics · {community.clusters.length} clusters
+      {community.books.length} books · {community.clusters.length} clusters
       {community.domain_label && (
         <span> · <span class="text-[var(--color-accent)]">{community.domain_label}</span></span>
       )}

--- a/web/src/pages/communities/index.astro
+++ b/web/src/pages/communities/index.astro
@@ -50,7 +50,7 @@ if (domainId != null) {
         cluster_id: community.community_id,
         community_id: community.community_id,
         label: community.label,
-        size: community.topic_count,
+        size: community.cluster_count,
         book_count: community.book_count,
         sample_books: community.sample_books,
       }} />
@@ -114,7 +114,7 @@ if (domainId != null) {
     // Stats
     const stats = document.createElement('p');
     stats.className = 'text-xs text-[var(--color-text-muted)] text-center';
-    stats.textContent = `${community.book_count} books · ${community.topic_count} topics`;
+    stats.textContent = `${community.book_count} books · ${community.cluster_count ?? community.topic_count} clusters`;
     card.appendChild(stats);
 
     return card;


### PR DESCRIPTION
## Summary
- Replace raw Leiden topic counts/chips with cluster counts/labels across the entire UI (universe tooltips, sidebar panels, community pages, theme cards)
- Rename "Domains" → "Themes" in all user-facing text (legend, multi-select panel)
- Add per-DB-variant universe JSON paths so demo and v2 databases don't overwrite each other (#64)
- Fix About page: update search signal counts (7→6, 5→4) after topic_vectors optimization, add "Reading the UI" section, add ONNX Runtime to tech stack
- Add `docs/libtrails_architecture.md` — blog-ready writeup covering pipeline architecture, ONNX embedding optimization, and search speed improvements

Closes #63, closes #64

## Test plan
- [ ] Universe tooltip shows "N books · N clusters" with cluster label chips
- [ ] Universe sidebar legend says "Themes" (not "Domains")
- [ ] Sidebar community panel shows cluster labels, no raw topic chips
- [ ] Topics list page cards show "N books · N clusters"
- [ ] Community detail page shows "N books · N clusters · Theme Name"
- [ ] About page: "6 Search signals" stat, "Hybrid Book Search" section with 6 signals listed
- [ ] About page: "Reading the UI" section visible between Pipeline and Search
- [ ] About page: ONNX Runtime in tech stack table
- [ ] `LIBTRAILS_DB=demo` and `LIBTRAILS_DB=v2` use separate universe JSON files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Community and universe views now surface cluster metrics (cluster counts and top clusters) in listings and search results.

* **Documentation**
  * Added detailed LibTrails architecture doc describing pipeline, embeddings, clustering, and performance/metrics.
  * Updated About page with refreshed hybrid search narrative and UI hierarchy.

* **Improvements**
  * UI terminology unified: topics/domains → clusters/themes; counts and labels updated across the app.
  * Hybrid search signal set reduced for faster, simpler results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->