### PR TITLE
fix: unify match-badge UX across search surfaces

### DIFF
--- a/web/src/components/RelatedBooks.astro
+++ b/web/src/components/RelatedBooks.astro
@@ -2,6 +2,7 @@
 import type { RelatedBook } from '../lib/types';
 import BookCover from './BookCover.astro';
 import { url } from '../lib/url';
+import { matchBadgeLabel, matchBadgeClasses } from '../lib/matchBadge';
 
 interface Props {
   books: RelatedBook[];
@@ -36,12 +37,9 @@ const { books } = Astro.props;
               <span class="text-xs text-[var(--color-text-muted)]">
                 {Math.round(book.similarity * 100)}%
               </span>
-              {book.match_type && (
-                <span class:list={[
-                  "match-badge",
-                  `match-badge--${book.match_type}`
-                ]}>
-                  {book.match_type}
+              {book.match_type && matchBadgeLabel(book.match_type) && (
+                <span class:list={matchBadgeClasses(book.match_type)}>
+                  {matchBadgeLabel(book.match_type)}
                 </span>
               )}
             </div>
@@ -59,23 +57,6 @@ const { books } = Astro.props;
     -webkit-box-orient: vertical;
     overflow: hidden;
   }
-
-  .match-badge {
-    display: inline-block;
-    padding: 0 4px;
-    font-size: 0.6rem;
-    line-height: 1.4;
-    border-radius: 3px;
-    background: var(--color-bg);
-    border: 1px solid var(--color-border);
-    color: var(--color-text-muted);
-  }
-
-  .match-badge--keyword { border-color: #f59e0b; color: #f59e0b; }
-  .match-badge--theme { border-color: #8b5cf6; color: #8b5cf6; }
-  .match-badge--book { border-color: #3b82f6; color: #3b82f6; }
-  .match-badge--content { border-color: #10b981; color: #10b981; }
-  .match-badge--semantic { border-color: #06b6d4; color: #06b6d4; }
-  .match-badge--chunk_semantic { border-color: #06b6d4; color: #06b6d4; }
-  .match-badge--topic { border-color: #6366f1; color: #6366f1; }
+  /* .match-badge styles live in web/src/styles/global.css so the vocabulary
+     stays identical across every surface (main search, related-books, etc.). */
 </style>

--- a/web/src/lib/matchBadge.ts
+++ b/web/src/lib/matchBadge.ts
@@ -1,0 +1,31 @@
+// Match-badge vocabulary for hybrid-search results.
+//
+// The backend's hybrid_search pipeline fuses multiple retrieval signals via
+// Reciprocal Rank Fusion. For each result, `match_type` names the signal where
+// the result achieved its best rank — the "dominant signal" that explains why
+// the result landed where it did. This module maps those raw signal names to
+// user-facing labels and CSS class lists so the UX stays consistent across
+// every surface that renders match badges (main book search, related-books,
+// etc.).
+//
+// The paired colors live in global.css under `.match-badge--<signal>`.
+
+export const MATCH_TYPE_LABELS: Record<string, string> = {
+  keyword: "Title/Author",
+  topic: "Topic",
+  content: "Content",
+  theme: "Theme",
+  book: "Book",
+  chunk: "Passage",
+  semantic: "Semantic",
+};
+
+export function matchBadgeLabel(matchType: string | undefined | null): string | null {
+  if (!matchType) return null;
+  return MATCH_TYPE_LABELS[matchType] ?? "Match";
+}
+
+export function matchBadgeClasses(matchType: string | undefined | null): string[] {
+  if (!matchType) return [];
+  return ["match-badge", `match-badge--${matchType}`];
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -159,7 +159,10 @@ export interface HybridBookResult {
   author: string;
   calibre_id: number | null;
   score: number;
-  match_type: "keyword" | "content" | "semantic" | "topic";
+  // Dominant-signal label from RRF fusion. See web/src/lib/matchBadge.ts for
+  // the rendered labels and backend src/libtrails/hybrid_search.py for the
+  // signal-to-label mapping produced by the fusion step.
+  match_type: "keyword" | "topic" | "content" | "theme" | "book" | "chunk" | "semantic";
 }
 
 export interface HybridClusterResult {

--- a/web/src/pages/books/index.astro
+++ b/web/src/pages/books/index.astro
@@ -62,14 +62,12 @@ const basePath = (import.meta.env.BASE_URL || "/").replace(/\/$/, "");
 </BaseLayout>
 
 <script>
+  import { matchBadgeLabel, matchBadgeClasses } from '../../lib/matchBadge';
+
   function createBookResultCard(result: any, basePath: string): HTMLElement {
     const coverUrl = result.calibre_id
       ? `${basePath}/api/v1/covers/${result.calibre_id}`
       : `${basePath}/placeholder-cover.svg`;
-    const matchBadge = result.match_type === 'keyword' ? 'Title/Author'
-      : result.match_type === 'content' ? 'Content'
-      : result.match_type === 'semantic' ? 'Semantic'
-      : 'Topic';
 
     const card = document.createElement('a');
     card.href = `${basePath}/books/${result.book_id}`;
@@ -98,13 +96,16 @@ const basePath = (import.meta.env.BASE_URL || "/").replace(/\/$/, "");
     author.className = 'text-sm text-[var(--color-text-muted)] mb-2';
     author.textContent = result.author;
 
-    const badge = document.createElement('span');
-    badge.className = 'text-xs px-2 py-0.5 rounded-full bg-[var(--color-bg)] text-[var(--color-text-muted)]';
-    badge.textContent = matchBadge;
-
     textWrap.appendChild(title);
     textWrap.appendChild(author);
-    textWrap.appendChild(badge);
+
+    const badgeLabel = matchBadgeLabel(result.match_type);
+    if (badgeLabel) {
+      const badge = document.createElement('span');
+      badge.className = matchBadgeClasses(result.match_type).join(' ');
+      badge.textContent = badgeLabel;
+      textWrap.appendChild(badge);
+    }
 
     card.appendChild(coverWrap);
     card.appendChild(textWrap);

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -138,3 +138,29 @@ h1, h2, h3, h4 {
 @keyframes spin {
   to { transform: rotate(360deg); }
 }
+
+/* Match badges — shared across every surface that renders hybrid-search
+   results (main book search, related-books, etc.). The color encodes which
+   retrieval signal dominated the result's ranking. See web/src/lib/matchBadge.ts
+   for the label mapping and backend src/libtrails/hybrid_search.py for the
+   signal-to-label mapping in the fusion step. */
+.match-badge {
+  display: inline-block;
+  padding: 0 6px;
+  font-size: 0.65rem;
+  line-height: 1.5;
+  border-radius: 3px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.match-badge--keyword  { border-color: #f59e0b; color: #f59e0b; }
+.match-badge--topic    { border-color: #6366f1; color: #6366f1; }
+.match-badge--content  { border-color: #10b981; color: #10b981; }
+.match-badge--theme    { border-color: #8b5cf6; color: #8b5cf6; }
+.match-badge--book     { border-color: #3b82f6; color: #3b82f6; }
+.match-badge--chunk    { border-color: #06b6d4; color: #06b6d4; }
+.match-badge--semantic { border-color: #06b6d4; color: #06b6d4; }


### PR DESCRIPTION
## Summary

- Unifies the hybrid-search match-badge UX so every result surface (main book search, related-books) renders the same colored-badge vocabulary with identical labels.
- Fixes a latent bug where `books/index.astro` recognized only 3 of the 6 `match_type` values the backend emits — theme / book / chunk matches all fell through to a generic "Topic" label, discarding the dominant-signal information the backend had already computed.
- Fixes a dead CSS class (`.match-badge--chunk_semantic`) that the backend never triggers and replaces it with the name the backend actually emits (`chunk`).

## What changed

- **New:** `web/src/lib/matchBadge.ts` — single source of truth mapping the six backend signal names (`keyword`, `topic`, `content`, `theme`, `book`, `chunk`) plus the legacy `semantic` label to user-facing display strings and CSS class lists.
- **Moved:** `.match-badge` styles from `RelatedBooks.astro` into `web/src/styles/global.css` so every surface picks them up through the shared stylesheet.
- **Updated:** `books/index.astro` now uses `matchBadgeLabel()` + `matchBadgeClasses()` to render the full colored badge vocabulary instead of a plain gray pill with only three recognized values.
- **Updated:** `RelatedBooks.astro` now uses `matchBadgeLabel()` so the badge shows human-friendly text ("Theme", "Passage", "Title/Author") rather than the raw signal name.
- **Widened:** `HybridBookResult.match_type` TypeScript union to cover every value the backend emits.

No backend changes. The backend's match_type emission from `hybrid_search.py` was already correct — this PR brings the frontend into alignment with what the backend has been producing all along.

## Why this matters

The backend's RRF fusion computes the dominant retrieval signal for every result and attaches it as `match_type`. Surfacing that to the user is a key explainability affordance for hybrid search — it tells the user *which* part of their query matched, which builds trust, aids query reformulation, and lets users diagnose weak results. The drift between surfaces meant this signal was only partially exposed: richly on the related-books strip, hobbled on the main search page.

## Test plan

- [ ] `npx astro build` clean (verified locally)
- [ ] Manual: run `/books` search for a title/author query — expect amber "Title/Author" badge
- [ ] Manual: run `/books` search for a conceptual query — expect blue "Book" or violet "Theme" or indigo "Topic" badge (not the previous generic "Topic" fallback for all three)
- [ ] Manual: run `/books` search for a content/phrase query — expect green "Content" or cyan "Passage" badge
- [ ] Manual: visit any book detail page, confirm related-books strip shows colored badges with friendly labels (e.g., "Theme" not "theme")
- [ ] Manual: light and dark theme both render badges legibly

## Follow-ups (not in this PR)

- Optional: expose RRF per-signal ranks for each result via a tooltip or expandable detail. The backend `best_signal` dict already has the data; rendering it is the UI work.
- Optional: emit the top-2 dominant signals when the second-place signal's rank is within a threshold of the first. Stronger explainability signal for convergent results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Match badges now support additional search signal types, providing enhanced insight into the different ways books match your search queries.
  * Refined visual styling and consistency of match badges throughout the application for improved clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->